### PR TITLE
Refactor of the adapters and replaced findViewById

### DIFF
--- a/iBuildApp1/app/build.gradle
+++ b/iBuildApp1/app/build.gradle
@@ -6,10 +6,6 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
 
-    dataBinding {
-        enabled = true
-    }
-
     defaultConfig {
         applicationId "com.ibuild.getac"
         minSdkVersion 21

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/EditAccountActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/EditAccountActivity.kt
@@ -3,12 +3,9 @@ package com.ibuild.getac
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.widget.LinearLayout
+import kotlinx.android.synthetic.main.activity_edit_account.*
 
 class EditAccountActivity : AppCompatActivity() {
-
-    private lateinit var editPersonalInfoBtn: LinearLayout
-    private lateinit var editPasswordBtn: LinearLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,15 +13,12 @@ class EditAccountActivity : AppCompatActivity() {
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        editPersonalInfoBtn = findViewById(R.id.btnAccountInfo)
-        editPasswordBtn = findViewById(R.id.btnAccountPassword)
-
-        editPersonalInfoBtn.setOnClickListener{
+        btnAccountInfo.setOnClickListener{
             val intent = Intent(this, EditPersonalInfoActivity::class.java)
             startActivity(intent)
         }
 
-        editPasswordBtn.setOnClickListener{
+        btnAccountPassword.setOnClickListener{
             val intent = Intent(this, EditPasswordActivity::class.java)
             startActivity(intent)
         }

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/EditPasswordActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/EditPasswordActivity.kt
@@ -4,26 +4,15 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.widget.Button
-import com.google.android.material.textfield.TextInputEditText
+import kotlinx.android.synthetic.main.activity_edit_password.*
 
 class EditPasswordActivity : AppCompatActivity() {
-
-    private lateinit var oldPassword: TextInputEditText
-    private lateinit var editPassword: TextInputEditText
-    private lateinit var editPasswordConfirm: TextInputEditText
-    private lateinit var btnSavePass: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_edit_password)
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-
-        oldPassword         = findViewById(R.id.oldPassword)
-        editPassword        = findViewById(R.id.editPassword)
-        editPasswordConfirm = findViewById(R.id.editPasswordConfirm)
-        btnSavePass         = findViewById(R.id.btnSavePasswordChanges)
 
         oldPassword.addTextChangedListener(enableButtonListener)
         editPassword.addTextChangedListener(enableButtonListener)
@@ -45,7 +34,7 @@ class EditPasswordActivity : AppCompatActivity() {
         }
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            btnSavePass.isEnabled = true
+            btnSavePasswordChanges.isEnabled = true
         }
 
     }

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/EditPersonalInfoActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/EditPersonalInfoActivity.kt
@@ -4,28 +4,15 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
-import android.widget.Button
-import com.google.android.material.textfield.TextInputEditText
+import kotlinx.android.synthetic.main.activity_edit_personal_info.*
 
 class EditPersonalInfoActivity : AppCompatActivity() {
-
-    private lateinit var editName: TextInputEditText
-    private lateinit var editLastName: TextInputEditText
-    private lateinit var editPhone: TextInputEditText
-    private lateinit var editEmail: TextInputEditText
-    private lateinit var btnSave: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_edit_personal_info)
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-
-        editName        = findViewById(R.id.editName)
-        editLastName    = findViewById(R.id.editLastName)
-        editPhone       = findViewById(R.id.editPhone)
-        editEmail       = findViewById(R.id.editEmail)
-        btnSave         = findViewById(R.id.btnSaveAccountInfoChanges)
 
         editName.addTextChangedListener(enableButtonListener)
         editLastName.addTextChangedListener(enableButtonListener)
@@ -48,7 +35,7 @@ class EditPersonalInfoActivity : AppCompatActivity() {
         }
 
         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-            btnSave.isEnabled = true
+            btnSaveAccountInfoChanges.isEnabled = true
         }
 
     }

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/LoginActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/LoginActivity.kt
@@ -4,27 +4,18 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
-import android.widget.Button
-import android.widget.TextView
+import kotlinx.android.synthetic.main.activity_login.*
 
 class LoginActivity : AppCompatActivity() {
-
-    private lateinit var btnLogin: Button
-    private lateinit var btnLoginGoogle: Button
-    private lateinit var btnRegister: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
-        btnLogin        = findViewById(R.id.btnLogin)
-        btnLoginGoogle  = findViewById(R.id.btnLoginGoogle)
-        btnRegister     = findViewById(R.id.btnRegisterLogin)
-
 
         btnLogin.setOnClickListener(mainIntent)
         btnLoginGoogle.setOnClickListener(mainIntent)
-        btnRegister.setOnClickListener{
+        btnRegisterLogin.setOnClickListener{
             val intent = Intent(this, RegisterActivity::class.java)
             startActivity(intent)
             finish()

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/RegisterActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/RegisterActivity.kt
@@ -3,27 +3,20 @@ package com.ibuild.getac
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.widget.Button
-import android.widget.TextView
+import kotlinx.android.synthetic.main.activity_register.*
 
 class RegisterActivity : AppCompatActivity() {
-
-    private lateinit var btnRegister: Button
-    private lateinit var btnLogin: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_register)
-
-        btnRegister     = findViewById(R.id.btnRegister)
-        btnLogin        = findViewById(R.id.btnLoginRegister)
 
         btnRegister.setOnClickListener{
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
             finish()
         }
-        btnLogin.setOnClickListener{
+        btnLoginRegister.setOnClickListener{
             val intent = Intent(this, LoginActivity::class.java)
             startActivity(intent)
             finish()

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/StoreActivity.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/StoreActivity.kt
@@ -3,24 +3,20 @@ package com.ibuild.getac
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.ibuild.getac.adapter.ProductItemListAdapter
-import com.ibuild.getac.databinding.ActivityStoreBinding
 import com.ibuild.getac.model.Product
+import com.ibuild.getac.model.Store
 import kotlinx.android.synthetic.main.activity_store.*
 
 class StoreActivity : AppCompatActivity() {
 
-    lateinit var binding : ActivityStoreBinding
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_store)
 
-        txtNameAdressStore.text = getIntent().getStringExtra("STORENAME")
-        txtAdressStore.text = getIntent().getStringExtra("STOREADRESS")
+        val store = intent.getSerializableExtra("STORE") as Store
+        txtNameAdressStore.text = store.storeName
+        txtAdressStore.text = store.storeAddress
 
         productList.adapter = ProductItemListAdapter(products(), this) {
             val intent = Intent(this, ProductActivity::class.java)

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/adapter/StoreCardListAdapter.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/adapter/StoreCardListAdapter.kt
@@ -6,44 +6,42 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.ibuild.getac.R
-import com.ibuild.getac.model.Product
 import com.ibuild.getac.model.Store
 import kotlinx.android.synthetic.main.store_card.view.*
 
-class StoreCardListAdapter(var items: List<Store>,
-                           var clickListener: OnStoreCardItemClickListener,
-                           var context: Context) : RecyclerView.Adapter<StoreCardViewHolder>() {
+class StoreCardListAdapter(private val stores: List<Store>,
+                           private val onClick: (Store) -> Unit,
+                           private val context: Context) : RecyclerView.Adapter<StoreCardListAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(context).inflate(R.layout.store_card, parent, false)
+        return ViewHolder(view)
+    }
 
     override fun getItemCount(): Int {
-        return items.size
+        return stores.size
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): StoreCardViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.store_card, parent, false)
-        return StoreCardViewHolder(view)
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val store = stores[position]
+        holder.bindView(store)
     }
 
-    override fun onBindViewHolder(holder: StoreCardViewHolder, position: Int) {
-        holder.initialize(items[position], clickListener)
-    }
-}
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
-class StoreCardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    val storeName = itemView.establishmentName
-    val storeAddress = itemView.establishmentDescription
-    //val storeRating = itemView.storeCardRating
+        fun bindView(store: Store) {
+            val storeName = itemView.establishmentName
+            val storeAddress = itemView.establishmentDescription
+            //val storeRating = itemView.storeCardRating
 
-    fun initialize(item: Store, action:OnStoreCardItemClickListener){
-        storeName.text = item.storeName
-        storeAddress.text = item.storeAddress
-        //storeRating.text = store.storeRating.toString() + "\u2605 (99+)"
+            storeName.text = store.storeName
+            storeAddress.text = store.storeAddress
+            //storeRating.text = store.storeRating.toString() + "\u2605 (99+)"
 
-        itemView.setOnClickListener{
-            action.onItemClick(item, adapterPosition)
+            itemView.setOnClickListener {
+                onClick(store)
+            }
         }
-    }
-}
 
-interface OnStoreCardItemClickListener{
-    fun onItemClick(item: Store, position: Int)
+    }
 }

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/AccountFragment.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/AccountFragment.kt
@@ -5,19 +5,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
 import com.ibuild.getac.EditAccountActivity
 import com.ibuild.getac.LoginActivity
 import com.ibuild.getac.R
 import com.ibuild.getac.SettingsActivity
+import kotlinx.android.synthetic.main.fragment_account.*
 
 class AccountFragment : Fragment() {
-
-    private lateinit var btnFav: LinearLayout
-    private lateinit var btnSettings: LinearLayout
-    private lateinit var btnEditAccount: LinearLayout
-    private lateinit var btnLogout: LinearLayout
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_account, container, false)
@@ -26,26 +21,21 @@ class AccountFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        btnFav = getView()?.findViewById(R.id.FavAccountLayout) as LinearLayout
-        btnSettings = getView()?.findViewById(R.id.SettingsAccountLayout) as LinearLayout
-        btnEditAccount = getView()?.findViewById(R.id.EditAccountLayout) as LinearLayout
-        btnLogout = getView()?.findViewById(R.id.LogoutAccountLayout) as LinearLayout
-
         /* TO DO: sem tela de favoritos ainda
-        btnFav.setOnClickListener{
+        FavAccountLayout.setOnClickListener{
             val intent = Intent(activity, Main::class.java)
             activity?.startActivity(intent)
         }
         */
-        btnSettings.setOnClickListener{
+        SettingsAccountLayout.setOnClickListener{
             val intent = Intent (activity, SettingsActivity::class.java)
             activity?.startActivity(intent)
         }
-        btnEditAccount.setOnClickListener{
+        EditAccountLayout.setOnClickListener{
             val intent = Intent (activity, EditAccountActivity::class.java)
             activity?.startActivity(intent)
         }
-        btnLogout.setOnClickListener{
+        LogoutAccountLayout.setOnClickListener{
             val intent = Intent (activity, LoginActivity::class.java)
             activity?.startActivity(intent)
             activity?.finish()

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/HomeFragment.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/HomeFragment.kt
@@ -10,18 +10,14 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.ibuild.getac.ProductActivity
 import com.ibuild.getac.R
 import com.ibuild.getac.StoreActivity
-import com.ibuild.getac.adapter.OnStoreCardItemClickListener
 import com.ibuild.getac.adapter.ProductCardListAdapter
 import com.ibuild.getac.adapter.StoreCardListAdapter
 import com.ibuild.getac.model.Product
 import com.ibuild.getac.model.Store
-import com.synnapps.carouselview.CarouselView
 import com.synnapps.carouselview.ImageListener
 import kotlinx.android.synthetic.main.fragment_home.*
 
-class HomeFragment : Fragment(), OnStoreCardItemClickListener {
-
-    private lateinit var carouselView: CarouselView
+class HomeFragment : Fragment() {
 
     //hardcoded, temporario enquanto não tem o banco de dados
     private val sampleImages = intArrayOf(
@@ -38,18 +34,22 @@ class HomeFragment : Fragment(), OnStoreCardItemClickListener {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        carouselView = getView()?.findViewById(R.id.homeCarousel) as CarouselView
-        carouselView.setImageListener(imageListener)
-        carouselView.pageCount = sampleImages.size
+        homeCarousel.setImageListener(imageListener)
+        homeCarousel.pageCount = sampleImages.size
 
-        hscroll1.adapter = getView()?.let {
-            StoreCardListAdapter(stores(), this, it.context)
+        hscroll1.adapter = getView()?.let { it ->
+            StoreCardListAdapter(stores(), {
+                val intent = Intent(activity, StoreActivity::class.java)
+                intent.putExtra("STORE", it)
+                startActivity(intent)
+            }, it.context)
         }
+
         val layoutManager1 = LinearLayoutManager(getView()?.context)
         layoutManager1.orientation = LinearLayoutManager.HORIZONTAL
         hscroll1.layoutManager = layoutManager1
 
-        hscroll2.adapter = getView()?.let {
+        hscroll2.adapter = getView()?.let { it ->
             ProductCardListAdapter(products(), {
                 val intent = Intent(activity, ProductActivity::class.java)
                 intent.putExtra("PRODUCT", it)
@@ -86,13 +86,5 @@ class HomeFragment : Fragment(), OnStoreCardItemClickListener {
             Product("Nome do produto 4", 7.50, "un", "Telhanorte"),
             Product("Nome do produto 5", 2.30, "metro", "Dicico")
         )
-    }
-
-    override fun onItemClick(item: Store, position: Int) {
-        val intent = Intent(activity, StoreActivity::class.java)
-        intent.putExtra("STORENAME", item.storeName)
-        intent.putExtra("STOREADRESS", item.storeAddress)
-        //intent.putExtra("STORERATING", item.storeRating.toString())
-        startActivity(intent)
     }
 }

--- a/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/ReformFragment.kt
+++ b/iBuildApp1/app/src/main/java/com/ibuild/getac/ui/ReformFragment.kt
@@ -5,15 +5,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.viewpager.widget.ViewPager
-import com.google.android.material.tabs.TabLayout
 import com.ibuild.getac.R
 import com.ibuild.getac.adapter.ReformTabsAdapter
+import kotlinx.android.synthetic.main.fragment_reform.*
 
 class ReformFragment : Fragment() {
-
-    private lateinit var viewPager: ViewPager
-    private lateinit var tabLayout: TabLayout
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_reform, container, false)
@@ -22,11 +18,8 @@ class ReformFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        viewPager = getView()?.findViewById(R.id.viewPager) as ViewPager
-        tabLayout = getView()?.findViewById(R.id.reformTabs) as TabLayout
-
         val fragmentAdapter = ReformTabsAdapter(parentFragmentManager)
         viewPager.adapter = fragmentAdapter
-        tabLayout.setupWithViewPager(viewPager)
+        reformTabs.setupWithViewPager(viewPager)
     }
 }


### PR DESCRIPTION
Mudei a maneira que os adapters implementam o click listener nos seus itens, de uma interface para uma função de uma classe interna.
Além disso, por motivos de null safety, type safety e boilerplate code, todas as chamadas ao método findViewById foram retiradas e as referências agora são feitas pelo Kotlin Synthetics.
